### PR TITLE
Add windowed write to GCS

### DIFF
--- a/project-5/README.MD
+++ b/project-5/README.MD
@@ -1,1 +1,12 @@
 # project-5
+
+This repository contains a small Apache Beam streaming example. Data is read
+from a Pub/Sub subscription, archived to Cloud Storage and written to BigQuery.
+
+### Running the pipeline
+
+```
+python stream_pipeline.py
+```
+
+`stream_simulator.py` can be used to publish test events to the Pub/Sub topic.

--- a/project-5/stream_pipeline.py
+++ b/project-5/stream_pipeline.py
@@ -1,8 +1,8 @@
 # simple_streaming_pipeline.py
 import apache_beam as beam
 from apache_beam.options.pipeline_options import PipelineOptions
+from apache_beam import window
 import json
-import time
 
 def run():
     options = PipelineOptions(
@@ -15,27 +15,40 @@ def run():
     )
 
     with beam.Pipeline(options=options) as p:
-        # 1. Read from Pub/Sub
-        messages = p | 'ReadFromPubSub' >> beam.io.ReadFromPubSub(
-            subscription='projects/silent-octagon-460701-a0/subscriptions/stream-topic-sub')
-        
+        # 1. Read from Pub/Sub and decode bytes to string
+        messages = (
+            p
+            | 'ReadFromPubSub' >> beam.io.ReadFromPubSub(
+                subscription='projects/silent-octagon-460701-a0/subscriptions/stream-topic-sub'
+            ).with_output_types(bytes)
+            | 'DecodeMessage' >> beam.Map(lambda x: x.decode('utf-8'))
+        )
 
+        # 2. Write raw data to Cloud Storage using windowing to avoid
+        #    GroupByKey errors with unbounded data
+        _ = (
+            messages
+            | 'WindowRawMessages' >> beam.WindowInto(window.FixedWindows(60))
+            | 'WriteRawToGCS' >> beam.io.WriteToText(
+                'gs://stream-topic-bucket/raw/messages',
+                file_name_suffix='.json'
+            )
+        )
 
-        # 2. Parse JSON (no error handling)
-        parsed = (messages
-                 | 'ParseJSON' >> beam.Map(lambda x: json.loads(x.decode('utf-8')))
-                 )
+        # 3. Parse JSON
+        parsed = messages | 'ParseJSON' >> beam.Map(json.loads)
 
-        # 3. Write to BigQuery (new table and schema with timestamp as STRING)
-        _ = (parsed
-             | 'WriteToBigQuery' >> beam.io.WriteToBigQuery(
-                 table='silent-octagon-460701-a0:stream_topic_dataset.stream_topic_table2',
-                 schema='user_id:INTEGER,action:STRING,product:STRING,timestamp:STRING',
-                 create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
-                 write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND)
-             )
+        # 4. Write to BigQuery (new table and schema with timestamp as STRING)
+        _ = (
+            parsed
+            | 'WriteToBigQuery' >> beam.io.WriteToBigQuery(
+                table='silent-octagon-460701-a0:stream_topic_dataset.stream_topic_table2',
+                schema='user_id:INTEGER,action:STRING,product:STRING,timestamp:STRING',
+                create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
+                write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND
+            )
+        )
 
       
 
-if __name__ == '__main__':
-    run()
+if __name__ == '__main__':    run()


### PR DESCRIPTION
## Summary
- write raw Pub/Sub messages to GCS using FixedWindows
- add decode step for Pub/Sub messages
- update README with usage instructions

## Testing
- `python -m py_compile stream_pipeline.py`
- `python -m py_compile stream_simulator.py`


------
https://chatgpt.com/codex/tasks/task_e_686ef3782844832b9f6a77d1a710802c